### PR TITLE
 Add a longer timeout between API task requests

### DIFF
--- a/wtt.js
+++ b/wtt.js
@@ -55,6 +55,7 @@ window.WTT = {};
 			idBoard = data.id;
 
 			var newLists = [];
+			var timeOutCounter = 0;
 			lists.forEach(function(l, li) {
 				Trello.post("/lists/", {
 					name: l.title,
@@ -85,10 +86,11 @@ window.WTT = {};
 							idList: data.id,
 							desc: desc,
 						};
-
-						// max 10 requests per s
-						window.setTimeout(_postTask.bind(null, task), li * ti * 100);
+						timeOutCounter += 1000; //Add 1s between each task API request
+						window.setTimeout(_postTask.bind(null, task), timeOutCounter);
 					}).bind(data));
+					// Optionally log the value of Timeout Counter so users can know how long the import will take
+					// console.log("Timeout Counter is: " + timeOutCounter); 
 				}).bind(l), function(resp) {
 					alert("Trello API error: ");
 				});


### PR DESCRIPTION
Added a timeOutCounter that increments with 1000ms with every task, so that each Add Task API request has 1s between it.
The existing code will still hammer the API with a lot of requests and start failing once 429 & 309 codes start being returned by the API.
I've also added some optional logging for users to enable if they wish to see the value of the counter.

Not the best code I know, I'm no expert, but it worked much better with my 12 lists and 277 tasks that imported with no problems whatsoever with the new code (and were failing to be imported with the existing code)